### PR TITLE
feat(testbed): Hetzner HIL deploy pipeline + mise.toml fixes

### DIFF
--- a/backends/foundation_testbed/HETZNER.md
+++ b/backends/foundation_testbed/HETZNER.md
@@ -1,0 +1,179 @@
+# foundation_testbed on Hetzner
+
+Drive the testbed remotely on a Hetzner Cloud box. QEMU uses `/dev/kvm`
+if present and falls back to TCG (10–50× slower per the README) if not —
+**so KVM is a performance upgrade, not a hard requirement**. Start cheap,
+upgrade if needed.
+
+The mise tasks in `mise.toml` are the single source of truth.
+This doc explains the **shape** of the pipeline so Alex (or you next
+month) can navigate it.
+
+**Toolchain:** everything mise-installed. `hcloud` for the API,
+`zig` + `cargo-zigbuild` for cross-compile from any host to Linux musl.
+No brew, no apt, no GCC source builds. Cross-build to a 6 MB
+statically-linked binary from a Mac in ~2 min.
+
+**Host OS support:** macOS and Linux work natively. Windows devs should
+run from **WSL** — task scripts use `bash`, which WSL provides and mise
+runs the same as on Linux. `zig` and `cargo-zigbuild` themselves have
+native Windows builds too, so cross-compiling on Windows works
+mechanically; WSL is just the path that doesn't require rewriting every
+task script.
+
+## Three phases
+
+```
+┌──────────────────────────┐
+│ Phase 1: host:*          │  Hetzner box lifecycle
+│   up / bootstrap /       │  (persistent, idempotent;
+│   deploy / ssh /         │   never auto-deletes)
+│   status / down          │
+└────────────┬─────────────┘
+             │
+┌────────────▼─────────────┐
+│ Phase 2: vm:*            │  testbed binary on the
+│   doctor / import /      │  remote host, driven via
+│   start / stop           │  ssh
+└────────────┬─────────────┘
+             │
+┌────────────▼─────────────┐
+│ Phase 3: hil:*           │  Orchestrators that
+│   probe / probe-kvm /    │  compose host:* + vm:*
+│   up / down              │
+└──────────────────────────┘
+```
+
+Plus a small `hcloud:*` namespace for one-time things (token, ssh-key,
+nuke-all).
+
+## Task surface
+
+Run from inside `backends/foundation_testbed/`.
+
+### hcloud:* — one-time utility
+
+| Task | What |
+|---|---|
+| `hcloud:context` | Save your Hetzner API token in `~/.config/hcloud/cli.toml` |
+| `hcloud:check` | Verify auth works (used as a precondition by `host:up` and `hil:probe-kvm`) |
+| `hcloud:ssh-key` | Upload your local public key to Hetzner |
+| `hcloud:teardown` | Delete every server + key + the local context (full reset) |
+
+### Local build
+
+| Task | What |
+|---|---|
+| `build` | Native build for your host (`cargo build --release --features cli`) — local dev only |
+| `cross:build` | Cross-compile via `cargo-zigbuild` for `x86_64-unknown-linux-musl` — produces the Hetzner-deployable binary |
+
+### host:* — Phase 1, Hetzner box lifecycle
+
+| Task | What |
+|---|---|
+| `host:up` | Create the persistent box (idempotent; skips if it already exists) |
+| `host:bootstrap` | `apt install qemu-system-x86 qemu-utils ovmf …` |
+| `host:deploy` | `scp` the cross-built testbed binary to `/usr/local/bin/testbed` |
+| `host:ssh` | Interactive SSH into the host |
+| `host:status` | Active context + server list + key list |
+| `host:down` | Delete the host (the **only** task that deletes; requires confirmation) |
+
+### vm:* — Phase 2, testbed binary on the remote host
+
+Each `vm:*` task is essentially `ssh root@host -- testbed <subcommand>`.
+
+| Task | What |
+|---|---|
+| `vm:doctor` | Health check on the remote host |
+| `vm:import <profile>` | Download a VM image (e.g. `linux-build`, `windows-build`) |
+| `vm:start <profile>` | Start a VM (headless) |
+| `vm:stop <profile>` | Stop a VM |
+
+### hil:* — Phase 3, orchestrators
+
+| Task | What | Composes (serial) |
+|---|---|---|
+| `hil:probe-kvm` | Throwaway probe: spin small box, check `/dev/kvm`, destroy | (standalone) |
+| `hil:probe` | First-time setup + probe | `hcloud:context` → `hcloud:ssh-key` → `hil:probe-kvm` |
+| `hil:up` | Cross-compile binary, bring up host, deploy, doctor | `cross:build` → `host:up` → `host:bootstrap` → `host:deploy` → `vm:doctor` |
+| `hil:down` | Tear down the persistent host | `host:down` |
+
+`hil:probe` and `hil:up` execute their steps **serially** via `mise run`
+inside a script — guarantees order without forcing each step to declare
+inter-task `depends`.
+
+## Workflows
+
+### First-time setup (today)
+
+```bash
+cd backends/foundation_testbed
+mise run hil:probe
+```
+
+Prompts for API token, uploads SSH key, spins a CCX13 for ~3 min, probes
+`/dev/kvm`, prints the result, destroys the probe server. Total cost
+~€0.02.
+
+### Regular use (after probe passes)
+
+```bash
+mise run hil:up                  # ensure host is up + provisioned
+mise run vm:import linux-build   # pull a VM image (one time)
+mise run vm:start  linux-build   # boot it
+# ... work ...
+mise run vm:stop   linux-build
+# host stays up; no charges for VMs themselves
+```
+
+### Stop paying
+
+```bash
+mise run host:down               # deletes the host; everything on it is gone
+```
+
+### Full reset (e.g. before handing off the project)
+
+```bash
+mise run hcloud:teardown
+```
+
+Then delete the empty project shell + revoke the API token in the
+web console (one click, the API can't do this part).
+
+## Defaults (override via env)
+
+| Var | Default | Notes |
+|---|---|---|
+| `HETZNER_HOST_NAME` | `testbed-host` | Persistent server name |
+| `HETZNER_HOST_TYPE` | `ccx23` | 4 dedicated vCPU, 16 GB — fits one heavy build VM |
+| `HETZNER_HOST_LOCATION` | `fsn1` | Falkenstein |
+| `HETZNER_HOST_IMAGE` | `ubuntu-24.04` | |
+| `HETZNER_PROBE_TYPE` | `ccx13` | Cheapest probe |
+| `HETZNER_SSH_KEY` | `~/.ssh/id_ed25519` | Local private key (override for a dedicated Hetzner key) |
+| `HETZNER_SSH_KEY_NAME` | `$USER-laptop` | Hetzner-side key registration name |
+
+Full env list documented in the header of `mise.toml`.
+
+## Not yet implemented
+
+- **Migrate host scripts to nushell.** The repo already uses nushell on
+  the guest side (`install_nushell()` in `host_bootstrap/install.rs`;
+  `aqua:nushell/nushell` in the root `[tools]`). Bringing it host-side
+  for our `hil:*` / `host:*` / `vm:*` tasks would (a) bring consistency
+  with the testbed's "mise + nushell everywhere" design, and
+  (b) give Windows devs native support without WSL. Roughly 17 task
+  scripts to translate; defer until either Windows demand appears or
+  we're touching the tasks for another reason.
+- **State persistence** — when you `host:down`, everything on it is gone.
+  Pick one of Volume / Storage Box / R2 when this becomes a problem.
+- **Remote `--headful` access** — currently `vm:start` uses
+  `--headless`. For VNC over SSH or Tailscale, design that when we
+  actually need it.
+
+## Status
+
+- Local macOS build via `mise run build` works (release, 9.2 MB ARM64).
+- `cross:build` for Linux musl: **not done yet**.
+- Probe + host + vm + hil tasks: **written, not yet exercised**. Pending
+  the `hil:probe` run that confirms KVM availability on CCX.

--- a/backends/foundation_testbed/mise.toml
+++ b/backends/foundation_testbed/mise.toml
@@ -5,8 +5,18 @@
 PROJECT_ROOT = "{{config_root}}"
 
 [tools]
-# QEMU provider (Linux)
-"mise:qemu" = { version = "latest", os = "linux" }
+# QEMU is installed via `mise run sys:install-testbed` (root mise.toml),
+# which uses apt/pacman on Linux and points to UTM on macOS.
+
+# Hetzner Cloud CLI — drives remote VM provisioning for testbed deployment.
+hcloud = "latest"
+
+# Cross-compile toolchain (Rust → Linux musl from any host):
+#   zig provides the C cross-compiler + linker
+#   cargo-zigbuild wraps cargo to drive it
+# Together: ~75 MB, no brew/apt needed, no source builds.
+zig = "latest"
+"cargo:cargo-zigbuild" = "latest"
 
 [tasks.check]
 description = "Check testbed prerequisites"
@@ -45,6 +55,34 @@ cargo run --release -- stop "$PROFILE"
 description = "Run unit tests"
 run = "cargo test"
 
+[tasks.build]
+description = "Build testbed binary (release, with cli feature) — native target"
+run = "cargo build --release --features cli"
+
+[tasks."cross:build"]
+description = "Cross-compile testbed for x86_64-unknown-linux-musl (uses zig as linker via cargo-zigbuild)"
+run = """
+#!/usr/bin/env bash
+set -e
+TARGET="x86_64-unknown-linux-musl"
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Ensure the rustup target is installed
+if ! rustup target list --installed | grep -q "^${TARGET}$"; then
+    echo "Adding rustup target $TARGET..."
+    rustup target add "$TARGET"
+fi
+
+cd "$ROOT"
+cargo zigbuild --release --target "$TARGET" --features cli -p foundation_testbed --bin testbed
+
+BIN="$ROOT/target/$TARGET/release/testbed"
+echo ""
+echo "✓ Built: $BIN"
+file "$BIN" 2>/dev/null || true
+ls -lh "$BIN"
+"""
+
 [tasks.check-rust]
 description = "Run cargo check"
 run = "cargo check"
@@ -55,14 +93,6 @@ run = "cargo clippy -- -D warnings"
 
 [tasks.setup-smb]
 description = "Setup SMB for Windows VM mounting (requires sudo)"
-doc = """
-Configures the host system for QEMU's built-in SMB server.
-This allows Windows VMs to mount host directories via SMB.
-
-Run with: mise run setup-smb
-
-Note: Requires sudo to install system-wide Samba configuration.
-"""
 run = """
 #!/usr/bin/env bash
 set -e
@@ -93,16 +123,337 @@ echo "SMB setup complete!"
 
 [tasks.test-mount]
 description = "Test Windows SMB mount (starts VM, tests mount)"
-doc = """
-Runs the Windows SMB mount E2E test.
-This will:
-1. Start a Windows VM
-2. Test SMB mounting
-3. Report results
-
-Run with: mise run test-mount
-"""
 run = """
 #!/usr/bin/env bash
 cargo test --test e2e_tauri test_smb_mount_only -- --ignored --nocapture
 """
+
+# ============================================================================
+# Hetzner HIL pipeline — three phases: host / vm / hil
+# ============================================================================
+#  hcloud:*   one-time utility tasks (token, SSH key, full teardown)
+#  host:*     Phase 1 — Hetzner box lifecycle (idempotent, never auto-deletes)
+#  vm:*       Phase 2 — VMs on the remote host (via ssh + testbed binary)
+#  hil:*      Phase 3 — orchestrators that compose host:* + vm:*
+#
+# Env overrides (all have sensible defaults):
+#   HETZNER_CONTEXT        hcloud context name           (default: testbed)
+#   HETZNER_SSH_KEY        local private key path        (default: ~/.ssh/id_ed25519)
+#   HETZNER_SSH_KEY_NAME   Hetzner-side key name         (default: $USER-laptop)
+#   HETZNER_HOST_NAME      persistent host name          (default: testbed-host)
+#   HETZNER_HOST_TYPE      server type                   (default: ccx23)
+#   HETZNER_HOST_LOCATION  datacenter                    (default: fsn1)
+#   HETZNER_HOST_IMAGE     OS image                      (default: ubuntu-24.04)
+#   HETZNER_PROBE_TYPE     probe server type             (default: ccx13)
+
+# ─── hcloud: utility ────────────────────────────────────────────────────────
+
+[tasks."hcloud:context"]
+description = "Save Hetzner API token in hcloud's local config (idempotent, interactive)"
+run = """
+#!/usr/bin/env bash
+set -e
+CTX="${HETZNER_CONTEXT:-testbed}"
+if hcloud context list 2>/dev/null | awk '{print $2}' | grep -qx "$CTX"; then
+    echo "✓ hcloud context '$CTX' already exists"
+else
+    echo "Creating hcloud context '$CTX' — paste your API token when prompted:"
+    hcloud context create "$CTX"
+fi
+hcloud context use "$CTX"
+echo "Active: $(hcloud context active)"
+"""
+
+[tasks."hcloud:ssh-key"]
+description = "Upload local SSH public key to Hetzner Cloud (idempotent)"
+run = """
+#!/usr/bin/env bash
+set -e
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+KEY_NAME="${HETZNER_SSH_KEY_NAME:-$USER-laptop}"
+PUB="${KEY_FILE}.pub"
+if [ ! -f "$PUB" ]; then
+    echo "ERROR: $PUB not found."
+    echo "       Generate one with: ssh-keygen -t ed25519 -f $KEY_FILE"
+    echo "       Or point at an existing key: export HETZNER_SSH_KEY=/path/to/private_key"
+    exit 1
+fi
+if hcloud ssh-key describe "$KEY_NAME" >/dev/null 2>&1; then
+    echo "✓ SSH key '$KEY_NAME' already registered with Hetzner"
+else
+    hcloud ssh-key create --name "$KEY_NAME" --public-key-from-file "$PUB"
+    echo "✓ Uploaded $PUB as Hetzner key '$KEY_NAME'"
+fi
+"""
+
+[tasks."hcloud:check"]
+description = "Verify hcloud is authenticated against the active project"
+run = """
+#!/usr/bin/env bash
+if ! hcloud server list >/dev/null 2>&1; then
+    echo "✗ hcloud not authenticated for context '$(hcloud context active 2>/dev/null || echo none)'."
+    echo "  Run: mise run hcloud:context"
+    exit 1
+fi
+echo "✓ Authenticated as context '$(hcloud context active)'"
+"""
+
+[tasks."hcloud:teardown"]
+description = "Delete ALL servers + SSH keys + local context (full reset)"
+confirm = "This deletes every server and SSH key in the active Hetzner project. Continue?"
+run = """
+#!/usr/bin/env bash
+set -e
+CTX="${HETZNER_CONTEXT:-testbed}"
+
+echo "Deleting all servers..."
+hcloud server list -o columns=name -o noheader 2>/dev/null | while read -r name; do
+    [ -n "$name" ] && hcloud server delete "$name" && echo "  deleted: $name"
+done
+
+echo "Deleting all SSH keys..."
+hcloud ssh-key list -o columns=name -o noheader 2>/dev/null | while read -r name; do
+    [ -n "$name" ] && hcloud ssh-key delete "$name" && echo "  deleted: $name"
+done
+
+echo "Removing local context '$CTX'..."
+hcloud context delete "$CTX" 2>/dev/null || true
+
+cat <<EOF
+
+✓ Hetzner resources + local context cleared.
+
+To fully delete the Hetzner project itself (the empty shell + revoke
+the API token), do it in the web console:
+  https://console.hetzner.cloud → project → Settings → bottom of page
+EOF
+"""
+
+# ─── host: Phase 1 — Hetzner box lifecycle ──────────────────────────────────
+
+[tasks."host:up"]
+description = "Create the persistent testbed host (idempotent; safe to re-run)"
+depends = ["hcloud:check", "hcloud:ssh-key"]
+run = """
+#!/usr/bin/env bash
+set -e
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+TYPE="${HETZNER_HOST_TYPE:-ccx23}"
+IMAGE="${HETZNER_HOST_IMAGE:-ubuntu-24.04}"
+LOCATION="${HETZNER_HOST_LOCATION:-fsn1}"
+KEY_NAME="${HETZNER_SSH_KEY_NAME:-$USER-laptop}"
+
+if hcloud server describe "$NAME" >/dev/null 2>&1; then
+    echo "✓ Host '$NAME' already exists at $(hcloud server ip "$NAME")"
+    exit 0
+fi
+
+echo "Creating $NAME ($TYPE, $IMAGE, $LOCATION)..."
+hcloud server create \
+    --name "$NAME" \
+    --type "$TYPE" \
+    --image "$IMAGE" \
+    --location "$LOCATION" \
+    --ssh-key "$KEY_NAME"
+
+IP=$(hcloud server ip "$NAME")
+echo "✓ $NAME created at $IP"
+"""
+
+[tasks."host:bootstrap"]
+description = "Install QEMU + KVM userspace on the host (idempotent)"
+run = """
+#!/usr/bin/env bash
+set -e
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+IP=$(hcloud server ip "$NAME") || { echo "ERROR: host '$NAME' not found. Run host:up first."; exit 1; }
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY_FILE"
+ssh $SSH_OPTS "root@$IP" '
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq qemu-system-x86 qemu-utils ovmf curl tar xz-utils
+    echo "✓ QEMU $(qemu-system-x86_64 --version | head -1)"
+    ls -l /dev/kvm 2>/dev/null && echo "✓ /dev/kvm available" || echo "⚠ /dev/kvm MISSING — QEMU will run in TCG (slow)"
+'
+"""
+
+[tasks."host:deploy"]
+description = "Copy local testbed binary to the host's /usr/local/bin"
+run = """
+#!/usr/bin/env bash
+set -e
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+BIN="$(git rev-parse --show-toplevel)/target/x86_64-unknown-linux-musl/release/testbed"
+if [ ! -f "$BIN" ]; then
+    echo "ERROR: $BIN not found. Build the Linux musl binary first:"
+    echo ""
+    if [[ "$(uname)" == "Darwin" ]]; then
+        echo "  macOS prereqs:  brew install FiloSottile/musl-cross/musl-cross"
+        echo "                  rustup target add x86_64-unknown-linux-musl"
+        echo "                  add to .cargo/config.toml:"
+        echo "                    [target.x86_64-unknown-linux-musl]"
+        echo "                    linker = \\"x86_64-linux-musl-gcc\\""
+    else
+        echo "  Linux prereqs:  sudo apt install -y musl-tools  (or distro equivalent)"
+        echo "                  rustup target add x86_64-unknown-linux-musl"
+    fi
+    echo ""
+    echo "  Then:  cargo build --release --features cli --target x86_64-unknown-linux-musl -p foundation_testbed --bin testbed"
+    exit 1
+fi
+IP=$(hcloud server ip "$NAME")
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY_FILE"
+scp $SSH_OPTS "$BIN" "root@$IP:/usr/local/bin/testbed"
+ssh $SSH_OPTS "root@$IP" "chmod +x /usr/local/bin/testbed && testbed --version 2>&1 | head -1"
+echo "✓ Deployed to $NAME"
+"""
+
+[tasks."host:ssh"]
+description = "Open an interactive SSH session on the host"
+run = """
+#!/usr/bin/env bash
+set -e
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+IP=$(hcloud server ip "$NAME")
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY_FILE" "root@$IP"
+"""
+
+[tasks."host:status"]
+description = "Show host state + all servers/keys in the project"
+run = """
+#!/usr/bin/env bash
+echo "=== Active context ===";   hcloud context active || true
+echo ""
+echo "=== Servers ===";          hcloud server list
+echo ""
+echo "=== SSH keys ===";         hcloud ssh-key list
+"""
+
+[tasks."host:down"]
+description = "Delete the persistent testbed host (the ONLY way to remove it)"
+confirm = "Delete the testbed host? Any VMs and unsaved state on it will be lost."
+run = """
+#!/usr/bin/env bash
+set -e
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+hcloud server delete "$NAME" && echo "✓ $NAME deleted"
+"""
+
+# ─── vm: Phase 2 — VMs on the remote host via testbed binary ────────────────
+
+[tasks."vm:doctor"]
+description = "Run `testbed doctor` on the remote host"
+run = """
+#!/usr/bin/env bash
+set -e
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+IP=$(hcloud server ip "$NAME")
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY_FILE" "root@$IP" "testbed doctor"
+"""
+
+[tasks."vm:import"]
+description = "Import a VM profile on the host (e.g. linux-build, windows-build)"
+run = """
+#!/usr/bin/env bash
+set -e
+PROFILE="${1:?profile name required, e.g. linux-build}"
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+IP=$(hcloud server ip "$NAME")
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY_FILE" "root@$IP" "testbed import $PROFILE"
+"""
+
+[tasks."vm:start"]
+description = "Start a VM profile on the host"
+run = """
+#!/usr/bin/env bash
+set -e
+PROFILE="${1:?profile name required}"
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+IP=$(hcloud server ip "$NAME")
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY_FILE" "root@$IP" "testbed start $PROFILE --headless"
+"""
+
+[tasks."vm:stop"]
+description = "Stop a VM profile on the host"
+run = """
+#!/usr/bin/env bash
+set -e
+PROFILE="${1:?profile name required}"
+NAME="${HETZNER_HOST_NAME:-testbed-host}"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+IP=$(hcloud server ip "$NAME")
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY_FILE" "root@$IP" "testbed stop $PROFILE"
+"""
+
+# ─── hil: Phase 3 — orchestrators ───────────────────────────────────────────
+
+[tasks."hil:probe-kvm"]
+description = "Throwaway probe: spin a small CCX, check /dev/kvm, destroy (~€0.02, ~3 min)"
+depends = ["hcloud:check", "hcloud:ssh-key"]
+run = """
+#!/usr/bin/env bash
+set -e
+NAME="kvm-probe-$(date +%s)"
+KEY_FILE="${HETZNER_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+KEY_NAME="${HETZNER_SSH_KEY_NAME:-$USER-laptop}"
+LOCATION="${HETZNER_HOST_LOCATION:-fsn1}"
+TYPE="${HETZNER_PROBE_TYPE:-ccx13}"
+IMAGE="${HETZNER_HOST_IMAGE:-ubuntu-24.04}"
+
+cleanup() { echo "Cleaning up $NAME..."; hcloud server delete "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "Creating $NAME ($TYPE, $IMAGE, $LOCATION)..."
+hcloud server create --name "$NAME" --type "$TYPE" --image "$IMAGE" --location "$LOCATION" --ssh-key "$KEY_NAME"
+IP=$(hcloud server ip "$NAME")
+echo "IP: $IP — waiting for SSH..."
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -i $KEY_FILE"
+for i in {1..30}; do
+    if ssh $SSH_OPTS "root@$IP" "echo ready" >/dev/null 2>&1; then echo "✓ SSH up"; break; fi
+    sleep 5
+done
+
+echo ""
+echo "=== KVM probe results ==="
+ssh $SSH_OPTS "root@$IP" '
+    echo "/dev/kvm:";              ls -l /dev/kvm 2>&1 | sed "s/^/  /"
+    echo "CPU virt flags:";        grep -E -o "vmx|svm" /proc/cpuinfo | sort -u | sed "s/^/  /"
+    echo "Nested KVM enabled:";    cat /sys/module/kvm_intel/parameters/nested 2>/dev/null | sed "s/^/  intel: /"
+                                   cat /sys/module/kvm_amd/parameters/nested 2>/dev/null | sed "s/^/  amd: /"
+'
+"""
+
+[tasks."hil:probe"]
+description = "First-time setup: save token, upload SSH key, run KVM probe (serial)"
+run = """
+#!/usr/bin/env bash
+set -e
+mise run hcloud:context
+mise run hcloud:ssh-key
+mise run hil:probe-kvm
+"""
+
+[tasks."hil:up"]
+description = "Bring up a ready host: create + install QEMU + deploy testbed + doctor (serial)"
+run = """
+#!/usr/bin/env bash
+set -e
+mise run cross:build
+mise run host:up
+mise run host:bootstrap
+mise run host:deploy
+mise run vm:doctor
+"""
+
+[tasks."hil:down"]
+description = "Tear down the persistent host"
+depends = ["host:down"]


### PR DESCRIPTION
## Summary

Two independent bundles in one branch. Happy to split into separate PRs if preferred.

### 1. `backends/foundation_testbed/mise.toml` fixes (safe to merge as-is)

- Remove `doc = """..."""` fields from `setup-smb`/`test-mount` tasks — mise 2026.x rejects the field, the file failed to parse on current mise.
- Remove `"mise:qemu" = {...}` line — `mise:` is not a valid backend prefix; warns 3× per invocation on macOS and would actively fail on Linux. QEMU install is already covered by the existing `sys:install-testbed`.
- Add a plain `[tasks.build]` (`cargo build --release --features cli`) — the file had no plain build task; `doctor` was the only path and that builds + runs.

### 2. Hetzner HIL pipeline (new, opinionated, **not yet exercised end-to-end**)

A staged mise task surface for shipping the testbed to a Hetzner Cloud box and driving it remotely. Cross-platform from any host via `cargo-zigbuild` (zig as linker) — no brew/apt/musl-cross/source builds. Locally verified that `mise run cross:build` from macOS produces a statically-linked 6.3 MB Linux x86_64-musl ELF in ~2 min.

Three phases plus utilities:

- `host:*` — persistent Hetzner box lifecycle (up / bootstrap / deploy / ssh / down)
- `vm:*` — remote testbed control over SSH (doctor / import / start / stop)
- `hil:*` — orchestrators that chain the above (probe, probe-kvm, up, down)
- `hcloud:*` — utility (context, check, ssh-key, teardown)

`hil:probe` and `hil:up` sequence steps via explicit `mise run` calls inside a script — sidesteps mise's parallel `depends` scheduling for steps with ordering requirements.

See [`backends/foundation_testbed/HETZNER.md`](backends/foundation_testbed/HETZNER.md) for the full task table, workflows, default env overrides, and an honest "Not yet implemented" section.

## Test plan

- [x] `mise tasks` parses cleanly (verified on mise 2026.5.5, macOS)
- [x] `mise run build` produces a working native binary (macOS ARM64, 9.2 MB)
- [x] `mise run cross:build` produces a statically-linked Linux x86_64-musl binary from macOS (6.3 MB)
- [ ] `mise run hil:probe` end-to-end (needs Hetzner token; pending)
- [ ] `mise run hil:up` end-to-end (depends on probe outcome)
- [ ] Linux host verification

## Known not-done (flagged in HETZNER.md)

- Nushell migration for host scripts — consistency with guest-side use + native Windows support. Defer until needed.
- VM state persistence across `host:down` cycles.
- Remote `--headful` workflow — currently `vm:start` uses `--headless`.